### PR TITLE
update make file commands to use go version based on compiler

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -13,10 +13,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Setup Go v1.21.8
-      with:
-        go-version: '1.21.8'
-      uses: actions/setup-go@v5
+
+    # - name: Setup Go v1.21.8
+    #   with:
+    #     go-version: '1.21.8'
+    #   uses: actions/setup-go@v5
+
     - name: Copy Env Files
       run: cp .env.example .env
       

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,7 +18,7 @@ jobs:
       run: cp .env.example .env
 
     - name: Bundle Go Plugin
-      run: sudo DOCKER_USER=root make go-bundle
+      run: DOCKER_USER=root make go-bundle
       
     - name: Upload Bundle
       uses: actions/upload-artifact@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,9 +16,6 @@ jobs:
 
     - name: Copy Env Files
       run: cp .env.example .env
-    
-    - name: Clean Go Plugin
-      run: DOCKER_USER=root make go-clean
 
     - name: Bundle Go Plugin
       run: DOCKER_USER=root make go-bundle

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    # - name: Setup Go v1.21.8
-    #   with:
-    #     go-version: '1.21.8'
-    #   uses: actions/setup-go@v5
+    
+    - name: Setup Go v1.22.7
+      with:
+        go-version: '1.22.7'
+      uses: actions/setup-go@v5
 
     - name: Copy Env Files
       run: cp .env.example .env

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,7 +18,7 @@ jobs:
       run: cp .env.example .env
 
     - name: Bundle Go Plugin
-      run: sudo DOCKER_USER=root make && make bundle
+      run: sudo DOCKER_USER=root make go-bundle
       
     - name: Upload Bundle
       uses: actions/upload-artifact@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,9 +16,12 @@ jobs:
 
     - name: Copy Env Files
       run: cp .env.example .env
-      
+    
+    - name: Clean Go Plugin
+      run: DOCKER_USER=root make go-clean
+
     - name: Bundle Go Plugin
-      run: DOCKER_USER=root make bundle
+      run: DOCKER_USER=root make go-bundle
       
     - name: Upload Bundle
       uses: actions/upload-artifact@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -10,13 +10,15 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      GOTOOLCHAIN: auto
 
     steps:
     - uses: actions/checkout@v4
     
-    - name: Setup Go v1.22.7
+    - name: Setup Go v1.22.x
       with:
-        go-version: '1.22.7'
+        go-version: '1.22.x'
       uses: actions/setup-go@v5
 
     - name: Copy Env Files

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,16 +14,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Go v1.21.8
-      with:
-        go-version: '1.21.8'
-      uses: actions/setup-go@v5
-
     - name: Copy Env Files
       run: cp .env.example .env
       
     - name: Bundle Go Plugin
-      run: DOCKER_USER=root make bundle
+      run: sudo DOCKER_USER=root make bundle
       
     - name: Upload Bundle
       uses: actions/upload-artifact@v3
@@ -40,4 +35,3 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'us-east-1'   
         SOURCE_DIR: 'tyk/bundle'
-    

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,7 +18,7 @@ jobs:
       run: cp .env.example .env
 
     - name: Bundle Go Plugin
-      run: DOCKER_USER=root make go-bundle
+      run: sudo DOCKER_USER=root make && make bundle
       
     - name: Upload Bundle
       uses: actions/upload-artifact@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,7 +18,7 @@ jobs:
       run: cp .env.example .env
       
     - name: Bundle Go Plugin
-      run: sudo DOCKER_USER=root make bundle
+      run: DOCKER_USER=root make bundle
       
     - name: Upload Bundle
       uses: actions/upload-artifact@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -10,22 +10,20 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    env:
-      GOTOOLCHAIN: auto
 
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Setup Go v1.22.x
+
+    - name: Setup Go v1.21.8
       with:
-        go-version: '1.22.x'
+        go-version: '1.21.8'
       uses: actions/setup-go@v5
 
     - name: Copy Env Files
       run: cp .env.example .env
       
     - name: Bundle Go Plugin
-      run: DOCKER_USER=root make go-bundle
+      run: DOCKER_USER=root make bundle
       
     - name: Upload Bundle
       uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 go/src/go.mod
 go/src/go.sum
 go/src/vendor
+support/

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,20 @@ go-build: go/src/go.mod
 	docker compose run --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
 	mv -f ./go/src/CustomGoPlugin*.so ./tyk/middleware/
 
+go/src/go.mod:
+	cd ./go/src ; \
+	$(go-init) ; \
+	go get -d github.com/TykTechnologies/tyk@`git ls-remote https://github.com/TykTechnologies/tyk.git refs/tags/${TYK_VERSION} | awk '{print $$1;}'` ; \
+	$(go-tidy) ; \
+	$(go-vendor)
+
+# Builds Go plugin and moves it into local Tyk instance
+.PHONY: go-build
+go-build: go/src/go.mod
+	/bin/sh -c "cd ./go/src && $(go-tidy) && $(go-vendor)"
+	docker compose run --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
+	mv -f ./go/src/CustomGoPlugin*.so ./tyk/middleware/
+
 # Runs Go Linter
 lint:
 	/bin/sh -c "docker run --rm -v ${PWD}/go/src:/app -v ~/.cache/golangci-lint/v1.53.2:/root/.cache -w /app golangci/golangci-lint:v1.53.2 golangci-lint run"

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,8 @@ docker-clean:
 # Use go version and dependencies from Tyk Plugin Compiler instead of local to prevent version mismatch
 go-init:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod init tyk-plugin
 
+go-get:=go get -d github.com/TykTechnologies/tyk@`git ls-remote https://github.com/TykTechnologies/tyk.git refs/tags/${TYK_VERSION} | awk '{print $$1;}'`
+
 go-tidy:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod tidy
 
 go-vendor:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod vendor
@@ -110,14 +112,14 @@ go-vendor:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MO
 go/src/go.mod:
 	cd ./go/src ; \
 	$(go-init) ; \
-	go get -d github.com/TykTechnologies/tyk@`git ls-remote https://github.com/TykTechnologies/tyk.git refs/tags/${TYK_VERSION} | awk '{print $$1;}'` ; \
+	$(go-get); \
 	$(go-tidy) ; \
 	$(go-vendor)
 
 # Builds Go plugin and moves it into local Tyk instance
 .PHONY: go-build
 go-build: go/src/go.mod
-	/bin/sh -c "cd ./go/src && $(go-tidy) && $(go-vendor)"
+	/bin/sh -c "cd ./go/src && $(go-get) && $(go-tidy) && $(go-vendor)"
 	docker compose run --env GO_TIDY=1 --env GO_GET=1 --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
 	mv -f ./go/src/CustomGoPlugin*.so ./tyk/middleware/
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export TYK_VERSION := v5.3.9
+export TYK_VERSION := v5.7.2
 
 ifeq ($(origin DOCKER_USER), undefined)
 DOCKER_USER := 1000
@@ -101,13 +101,13 @@ docker-clean:
 	docker compose down --volumes --remove-orphans
 
 # Use go version and dependencies from Tyk Plugin Compiler instead of local to prevent version mismatch
-go-init:=docker container run -v ${PWD}:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod init tyk-plugin
+go-init:=docker compose run -v ${PWD}/go/src:/plugin-source -t --env GO_TIDY=1 --env GO_GET=1 --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tyk-plugin-compiler mod init tyk-plugin
 
 go-get:=go get -d github.com/TykTechnologies/tyk@`git ls-remote https://github.com/TykTechnologies/tyk.git refs/tags/${TYK_VERSION} | awk '{print $$1;}'`
 
-go-tidy:=docker container run -v ${PWD}:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod tidy
+go-tidy:=docker compose run -v ${PWD}/go/src:/plugin-source -t --env GO_TIDY=1 --env GO_GET=1 --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tyk-plugin-compiler mod tidy
 
-go-vendor:=docker container run -v ${PWD}:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod vendor
+go-vendor:=docker compose run -v ${PWD}/go/src:/plugin-source -t --env GO_TIDY=1 --env GO_GET=1 --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tyk-plugin-compiler mod vendor
 
 go/src/go.mod:
 	cd ./go/src ; \
@@ -117,10 +117,11 @@ go/src/go.mod:
 	$(go-vendor)
 
 # Builds Go plugin and moves it into local Tyk instance
+# docker compose run --env GO_TIDY=1 --env GO_GET=1 --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
 .PHONY: go-build
 go-build: go/src/go.mod
 	/bin/sh -c "cd ./go/src && $(go-tidy) && $(go-vendor)"
-	docker compose run --env GO_TIDY=1 --env GO_GET=1 --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
+	docker compose run -v ${PWD}/go/src:/plugin-source --env GO_TIDY=1 --env GO_GET=1 --env GO111MODULE=on --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
 	mv -f ./go/src/CustomGoPlugin*.so ./tyk/middleware/
 	ls -l && cat go.mod
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export TYK_VERSION := v5.3.0
+export TYK_VERSION := v5.3.9
 
 ifeq ($(origin DOCKER_USER), undefined)
 DOCKER_USER := 1000
@@ -73,17 +73,17 @@ docker-up:
 # Bring docker containers up /w oTel
 .PHONY: docker-up-otel
 docker-up-otel:
-	docker compose -f docker compose.yml -f deployments/otel/docker compose.yml up -d --remove-orphans tyk-dashboard tyk-gateway
+	docker compose -f docker-compose.yml -f deployments/otel/docker-compose.yml up -d --remove-orphans tyk-dashboard tyk-gateway
 
 # Bring docker containers up in OSS
 .PHONY: docker-up-oss
 docker-up-oss:
-	docker compose -f docker compose-oss.yml up -d --remove-orphans tyk-gateway
+	docker compose -f docker-compose-oss.yml up -d --remove-orphans tyk-gateway
 
 # Bring docker containers up in OSS /w oTel
 .PHONY: docker-up-oss-otel
 docker-up-oss-otel:
-	docker compose -f docker compose-oss.yml -f deployments/otel/docker compose.yml up -d --remove-orphans tyk-gateway
+	docker compose -f docker-compose-oss.yml -f deployments/otel/docker-compose.yml up -d --remove-orphans tyk-gateway
 
 # Bootstrap dashboard
 .PHONY: bootstrap
@@ -100,7 +100,7 @@ docker-down:
 docker-clean:
 	docker compose down --volumes --remove-orphans
 
-### Tyk Go Plugin ########################################################################
+# Use go version and dependencies from Tyk Plugin Compiler instead of local to prevent version mismatch
 go-init:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod init tyk-plugin
 
 go-tidy:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod tidy

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ go/src/go.mod:
 # Builds Go plugin and moves it into local Tyk instance
 .PHONY: go-build
 go-build: go/src/go.mod
-	/bin/sh -c "cd ./go/src && $(go-tidy) && $(go-vendor)"
+	/bin/sh -c "cd ./go/src && ls -l && $(go-tidy) && $(go-vendor)"
 	docker compose run --env GO_TIDY=1 --env GO_GET=1 --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
 	mv -f ./go/src/CustomGoPlugin*.so ./tyk/middleware/
 

--- a/Makefile
+++ b/Makefile
@@ -119,9 +119,10 @@ go/src/go.mod:
 # Builds Go plugin and moves it into local Tyk instance
 .PHONY: go-build
 go-build: go/src/go.mod
-	/bin/sh -c "cd ./go/src && ls -l && $(go-tidy) && $(go-vendor)"
+	/bin/sh -c "cd ./go/src && $(go-tidy) && $(go-vendor)"
 	docker compose run --env GO_TIDY=1 --env GO_GET=1 --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
 	mv -f ./go/src/CustomGoPlugin*.so ./tyk/middleware/
+	ls -l && cat go.mod
 
 # Runs Go Linter
 lint:

--- a/Makefile
+++ b/Makefile
@@ -101,13 +101,13 @@ docker-clean:
 	docker compose down --volumes --remove-orphans
 
 # Use go version and dependencies from Tyk Plugin Compiler instead of local to prevent version mismatch
-go-init:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod init tyk-plugin
+go-init:=docker container run -v ${PWD}:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod init tyk-plugin
 
 go-get:=go get -d github.com/TykTechnologies/tyk@`git ls-remote https://github.com/TykTechnologies/tyk.git refs/tags/${TYK_VERSION} | awk '{print $$1;}'`
 
-go-tidy:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod tidy
+go-tidy:=docker container run -v ${PWD}:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod tidy
 
-go-vendor:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod vendor
+go-vendor:=docker container run -v ${PWD}:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod vendor
 
 go/src/go.mod:
 	cd ./go/src ; \

--- a/Makefile
+++ b/Makefile
@@ -121,20 +121,6 @@ go-build: go/src/go.mod
 	docker compose run --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
 	mv -f ./go/src/CustomGoPlugin*.so ./tyk/middleware/
 
-go/src/go.mod:
-	cd ./go/src ; \
-	$(go-init) ; \
-	go get -d github.com/TykTechnologies/tyk@`git ls-remote https://github.com/TykTechnologies/tyk.git refs/tags/${TYK_VERSION} | awk '{print $$1;}'` ; \
-	$(go-tidy) ; \
-	$(go-vendor)
-
-# Builds Go plugin and moves it into local Tyk instance
-.PHONY: go-build
-go-build: go/src/go.mod
-	/bin/sh -c "cd ./go/src && $(go-tidy) && $(go-vendor)"
-	docker compose run --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
-	mv -f ./go/src/CustomGoPlugin*.so ./tyk/middleware/
-
 # Runs Go Linter
 lint:
 	/bin/sh -c "docker run --rm -v ${PWD}/go/src:/app -v ~/.cache/golangci-lint/v1.53.2:/root/.cache -w /app golangci/golangci-lint:v1.53.2 golangci-lint run"

--- a/Makefile
+++ b/Makefile
@@ -101,11 +101,11 @@ docker-clean:
 	docker compose down --volumes --remove-orphans
 
 ### Tyk Go Plugin ########################################################################
-go-init:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod init tyk-plugin
+go-init:=docker container run --user=$(DOCKER_USER) -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod init tyk-plugin
 
-go-tidy:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod tidy
+go-tidy:=docker container run --user=$(DOCKER_USER) -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod tidy
 
-go-vendor:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod vendor
+go-vendor:=docker container run --user=$(DOCKER_USER) -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod vendor
 
 go/src/go.mod:
 	cd ./go/src ; \
@@ -118,7 +118,7 @@ go/src/go.mod:
 .PHONY: go-build
 go-build: go/src/go.mod
 	/bin/sh -c "cd ./go/src && $(go-tidy) && $(go-vendor)"
-	docker compose run --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
+	docker compose run --env GO_TIDY=1 --env GO_GET=1 --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
 	mv -f ./go/src/CustomGoPlugin*.so ./tyk/middleware/
 
 # Runs Go Linter

--- a/Makefile
+++ b/Makefile
@@ -101,11 +101,11 @@ docker-clean:
 	docker compose down --volumes --remove-orphans
 
 ### Tyk Go Plugin ########################################################################
-go-init:=docker container run --user=$(DOCKER_USER) -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod init tyk-plugin
+go-init:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod init tyk-plugin
 
-go-tidy:=docker container run --user=$(DOCKER_USER) -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod tidy
+go-tidy:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod tidy
 
-go-vendor:=docker container run --user=$(DOCKER_USER) -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod vendor
+go-vendor:=docker container run -v ${PWD}/go/src:/plugin-source -t --env GO111MODULE=on --workdir /plugin-source --entrypoint go --rm tykio/tyk-plugin-compiler:${TYK_VERSION} mod vendor
 
 go/src/go.mod:
 	cd ./go/src ; \

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ go/src/go.mod:
 # Builds Go plugin and moves it into local Tyk instance
 .PHONY: go-build
 go-build: go/src/go.mod
-	/bin/sh -c "cd ./go/src && $(go-get) && $(go-tidy) && $(go-vendor)"
+	/bin/sh -c "cd ./go/src && $(go-tidy) && $(go-vendor)"
 	docker compose run --env GO_TIDY=1 --env GO_GET=1 --rm tyk-plugin-compiler CustomGoPlugin.so _$$(date +%s)
 	mv -f ./go/src/CustomGoPlugin*.so ./tyk/middleware/
 


### PR DESCRIPTION
Instead of relying on the go version installed locally the commands will reference the version set by the makefile and the tyk compiler container and it's respective go version to keep it consistent